### PR TITLE
fix: TypedDict 및 Annotated 스키마 추출 버그 수정

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests package

--- a/tests/test_a2a_lg_agent_executor_schema.py
+++ b/tests/test_a2a_lg_agent_executor_schema.py
@@ -1,0 +1,180 @@
+"""
+LangGraphWrappedA2AExecutor의 TypedDict/Annotated 스키마 처리 테스트
+
+이 테스트는 다양한 스키마 타입(TypedDict, Annotated, 중첩 구조 등)에서
+_get_graph_input_field_names() 메서드가 올바르게 필드명을 추출하는지 검증합니다.
+"""
+import os
+import sys
+import pytest
+
+# tests가 repo 루트에서 실행될 때 src 패키지 경로를 포함하도록 설정
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from src.a2a_integration.a2a_lg_agent_executor import LangGraphWrappedA2AExecutor
+
+# TypedDict / Annotated 호환성 처리
+try:
+    from typing import TypedDict, Annotated
+except ImportError:
+    # Python <3.9 또는 일부 환경
+    from typing_extensions import TypedDict, Annotated
+
+
+def _make_executor_for_schema(schema):
+    """테스트용 더미 그래프를 생성하여 Executor를 반환."""
+    class DummyGraph:
+        def get_input_schema(self):
+            return schema
+
+    return LangGraphWrappedA2AExecutor(graph=DummyGraph())
+
+
+class TestSimpleTypedDict:
+    """단순 TypedDict 테스트"""
+
+    def test_typedict_simple(self):
+        """기본 TypedDict가 정상적으로 필드를 추출하는지 검증."""
+        class SimpleTD(TypedDict):
+            a: int
+            b: str
+
+        ex = _make_executor_for_schema(SimpleTD)
+        result = ex._get_graph_input_field_names()
+        assert result == {"a", "b"}, f"Expected {{'a', 'b'}}, got {result}"
+
+
+class TestTypedDictWithAnnotatedFields:
+    """Annotated 필드를 포함한 TypedDict 테스트"""
+
+    def test_typedict_with_annotated_fields(self):
+        """TypedDict 내부 필드가 Annotated로 래핑된 경우 정상 처리."""
+        class TDAnnotatedFields(TypedDict):
+            x: Annotated[int, "meta"]
+            y: Annotated[str, "meta"]
+
+        ex = _make_executor_for_schema(TDAnnotatedFields)
+        result = ex._get_graph_input_field_names()
+        assert result == {"x", "y"}, f"Expected {{'x', 'y'}}, got {result}"
+
+
+class TestAnnotatedWrapperOverTypedDict:
+    """Annotated로 래핑된 TypedDict 테스트"""
+
+    def test_annotated_wrapper_over_typedict(self):
+        """TypedDict 전체가 Annotated로 래핑된 경우 언랩 후 필드 추출."""
+        class InnerTD(TypedDict):
+            foo: int
+            bar: str
+
+        Schema = Annotated[InnerTD, "wrapper-meta"]
+        ex = _make_executor_for_schema(Schema)
+        result = ex._get_graph_input_field_names()
+        assert result == {"foo", "bar"}, f"Expected {{'foo', 'bar'}}, got {result}"
+
+
+class TestRootWrappedDict:
+    """root dict로 래핑된 TypedDict 테스트"""
+
+    def test_root_wrapped_dict_contains_typedict(self):
+        """{'root': TypedDict} 형태에서 내부 TypedDict의 필드 추출."""
+        class InnerTD2(TypedDict):
+            u: int
+            v: str
+
+        schema = {"root": Annotated[InnerTD2, "meta"]}
+        ex = _make_executor_for_schema(schema)
+        result = ex._get_graph_input_field_names()
+        assert result == {"u", "v"}, f"Expected {{'u', 'v'}}, got {result}"
+
+
+class TestPlainDictSchema:
+    """일반 dict 스키마 테스트"""
+
+    def test_plain_dict_schema_keys_used(self):
+        """일반 dict 스키마의 경우 키를 직접 필드명으로 사용."""
+        schema = {"alpha": 1, "beta": "ok"}
+        ex = _make_executor_for_schema(schema)
+        result = ex._get_graph_input_field_names()
+        assert result == {"alpha", "beta"}, f"Expected {{'alpha', 'beta'}}, got {result}"
+
+
+class TestPydanticModel:
+    """Pydantic 모델 호환성 테스트"""
+
+    def test_pydantic_model_v2(self):
+        """Pydantic v2 모델이 기존처럼 정상 작동하는지 검증."""
+        try:
+            from pydantic import BaseModel
+
+            class MyModel(BaseModel):
+                field1: str
+                field2: int
+
+            ex = _make_executor_for_schema(MyModel)
+            result = ex._get_graph_input_field_names()
+            assert result == {"field1", "field2"}, f"Expected {{'field1', 'field2'}}, got {result}"
+        except ImportError:
+            pytest.skip("Pydantic not installed")
+
+
+class TestNestedTypedDict:
+    """중첩 TypedDict 테스트"""
+
+    def test_nested_typedict_fields(self):
+        """TypedDict 내부에 다른 TypedDict 필드가 있어도 최상위 필드만 추출."""
+        class NestedTD(TypedDict):
+            inner_a: str
+
+        class OuterTD(TypedDict):
+            outer_field: int
+            nested: NestedTD
+
+        ex = _make_executor_for_schema(OuterTD)
+        result = ex._get_graph_input_field_names()
+        assert result == {"outer_field", "nested"}, f"Expected {{'outer_field', 'nested'}}, got {result}"
+
+
+class TestEmptySchema:
+    """빈 스키마 처리 테스트"""
+
+    def test_none_schema(self):
+        """스키마가 None인 경우 빈 집합 반환."""
+        class DummyGraph:
+            def get_input_schema(self):
+                return None
+
+        ex = LangGraphWrappedA2AExecutor(graph=DummyGraph())
+        result = ex._get_graph_input_field_names()
+        assert result == set(), f"Expected empty set, got {result}"
+
+    def test_empty_typedict(self):
+        """필드가 없는 TypedDict도 처리 가능."""
+        class EmptyTD(TypedDict):
+            pass
+
+        ex = _make_executor_for_schema(EmptyTD)
+        result = ex._get_graph_input_field_names()
+        assert result == set(), f"Expected empty set, got {result}"
+
+
+class TestComplexAnnotations:
+    """복잡한 Annotated 구조 테스트"""
+
+    def test_multiple_annotated_layers(self):
+        """여러 단계의 Annotated 래핑도 처리."""
+        class BaseTD(TypedDict):
+            field_a: str
+            field_b: int
+
+        Schema = Annotated[Annotated[BaseTD, "meta1"], "meta2"]
+        ex = _make_executor_for_schema(Schema)
+        result = ex._get_graph_input_field_names()
+        assert result == {"field_a", "field_b"}, f"Expected {{'field_a', 'field_b'}}, got {result}"
+
+
+if __name__ == "__main__":
+    # 개별 실행 시 pytest 호출
+    pytest.main([__file__, "-v"])

--- a/tests/test_a2a_lg_integration.py
+++ b/tests/test_a2a_lg_integration.py
@@ -1,0 +1,181 @@
+"""
+LangGraph State 실제 통합 테스트
+
+실제 LangGraph의 BaseGraphState와 다양한 State 패턴에서
+_get_graph_input_field_names()와 _build_graph_input_from_payload()가
+올바르게 동작하는지 검증합니다.
+"""
+import os
+import sys
+import pytest
+
+# tests가 repo 루트에서 실행될 때 src 패키지 경로를 포함하도록 설정
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from src.a2a_integration.a2a_lg_agent_executor import LangGraphWrappedA2AExecutor
+from src.lg_agents.base.base_graph_state import BaseGraphState
+
+try:
+    from typing import TypedDict, Annotated
+except ImportError:
+    from typing_extensions import TypedDict, Annotated
+
+
+def _make_executor_with_graph_state(state_schema):
+    """실제 LangGraph StateGraph처럼 동작하는 더미 그래프 생성."""
+    class DummyCompiledGraph:
+        def __init__(self, schema):
+            self.schema = schema
+
+        def get_input_schema(self):
+            return self.schema
+
+        async def astream(self, input_data, config=None):
+            # 더미 스트림 (실제로는 사용 안 함)
+            yield {"messages": []}
+
+    return LangGraphWrappedA2AExecutor(graph=DummyCompiledGraph(state_schema))
+
+
+class TestBaseGraphStateIntegration:
+    """BaseGraphState를 사용하는 실제 케이스 테스트"""
+
+    def test_base_graph_state(self):
+        """BaseGraphState를 상속한 State가 messages 필드를 인식."""
+        from langchain_core.messages import BaseMessage
+
+        class MyAgentState(BaseGraphState):
+            additional_field: str
+
+        ex = _make_executor_with_graph_state(MyAgentState)
+        result = ex._get_graph_input_field_names()
+
+        # BaseGraphState는 messages 필드를 가지고 있어야 함
+        assert "messages" in result, f"Expected 'messages' in {result}"
+
+
+class TestTypedDictStateWithAnnotated:
+    """LangGraph에서 자주 사용되는 Annotated 필드 패턴"""
+
+    def test_typedict_with_annotated_reducer(self):
+        """Annotated를 사용한 리듀서 패턴이 정상 작동."""
+        def add_messages(left, right):
+            return left + right
+
+        class StateWithReducer(TypedDict):
+            messages: Annotated[list, add_messages]
+            notes: Annotated[list[str], add_messages]
+
+        ex = _make_executor_with_graph_state(StateWithReducer)
+        result = ex._get_graph_input_field_names()
+
+        assert result == {"messages", "notes"}, f"Expected {{'messages', 'notes'}}, got {result}"
+
+
+class TestBuildGraphInputIntegration:
+    """_build_graph_input_from_payload() 통합 테스트"""
+
+    def test_build_input_with_typedict_state(self):
+        """TypedDict State에 맞춰 payload를 변환."""
+        class SimpleTDState(TypedDict):
+            messages: list
+            user_id: str
+
+        ex = _make_executor_with_graph_state(SimpleTDState)
+
+        # 스키마 필드명 추출 확인
+        fields = ex._get_graph_input_field_names()
+        assert fields == {"messages", "user_id"}
+
+        # payload를 그래프 입력으로 변환
+        payload = {"user_id": "test_user", "extra_field": "extra_value"}
+        graph_input = ex._build_graph_input_from_payload(payload, query="Hello")
+
+        # user_id가 포함되고, messages가 HumanMessage로 생성됨
+        assert "user_id" in graph_input
+        assert graph_input["user_id"] == "test_user"
+        assert "messages" in graph_input
+        assert len(graph_input["messages"]) == 1
+
+        # extra_field도 보존됨 (스키마 외 키)
+        assert "extra_field" in graph_input
+
+
+    def test_build_input_with_existing_messages(self):
+        """payload에 이미 messages가 있는 경우 LangChain 메시지로 변환."""
+        class StateWithMessages(TypedDict):
+            messages: list
+
+        ex = _make_executor_with_graph_state(StateWithMessages)
+
+        # OpenAI 포맷의 메시지 리스트
+        payload = {
+            "messages": [
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "content": "Hello"}
+            ]
+        }
+
+        graph_input = ex._build_graph_input_from_payload(payload, query=None)
+
+        # messages가 LangChain Message 객체로 변환되었는지 확인
+        assert "messages" in graph_input
+        messages = graph_input["messages"]
+        assert len(messages) == 2
+
+        # LangChain 메시지 타입 확인
+        from langchain_core.messages import BaseMessage
+        assert all(isinstance(msg, BaseMessage) for msg in messages)
+
+
+class TestLookupMessagesField:
+    """_looks_like_messages_field() 메서드 테스트"""
+
+    def test_looks_like_messages_field(self):
+        """messages 관련 필드명을 올바르게 감지."""
+        class DummyGraph:
+            def get_input_schema(self):
+                return None
+
+        ex = LangGraphWrappedA2AExecutor(graph=DummyGraph())
+
+        assert ex._looks_like_messages_field("messages") is True
+        assert ex._looks_like_messages_field("Messages") is True
+        assert ex._looks_like_messages_field("chat_messages") is True
+        assert ex._looks_like_messages_field("user_id") is False
+        assert ex._looks_like_messages_field("notes") is False
+
+
+class TestRealWorldAgentState:
+    """실제 프로젝트에서 사용되는 AgentState 패턴 테스트"""
+
+    def test_deep_research_agent_state_pattern(self):
+        """Deep Research Agent의 State 구조를 시뮬레이션."""
+        from typing import Optional
+
+        def override_reducer(left, right):
+            return right if right is not None else left
+
+        class DeepResearchState(TypedDict):
+            messages: Annotated[list, override_reducer]
+            supervisor_messages: Annotated[list, override_reducer]
+            research_brief: Optional[str]
+            raw_notes: Annotated[list[str], override_reducer]
+            notes: Annotated[list[str], override_reducer]
+            final_report: str
+
+        ex = _make_executor_with_graph_state(DeepResearchState)
+        result = ex._get_graph_input_field_names()
+
+        expected = {
+            "messages", "supervisor_messages", "research_brief",
+            "raw_notes", "notes", "final_report"
+        }
+        assert result == expected, f"Expected {expected}, got {result}"
+
+
+if __name__ == "__main__":
+    # 개별 실행 시 pytest 호출
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

LangGraphWrappedA2AExecutor의 `_get_graph_input_field_names()` 메서드가 TypedDict 및 Annotated 타입을 제대로 처리하지 못하는 문제를 해결했습니다.

## Problem

기존 구현은 다음 케이스에서 실패했습니다:
- ❌ 단순 TypedDict: 필드명 추출 실패
- ❌ Annotated 필드를 가진 TypedDict: Annotated 언랩 불가
- ❌ Annotated로 래핑된 TypedDict: 외부 래핑 제거 실패  
- ❌ `{'root': TypedDict}` 구조: 중첩된 구조 탐색 불가
- ✅ Pydantic 모델만 정상 작동

## Solution

### 핵심 개선사항

1. **`_unwrap_annotated()` 함수 추가**
   - Annotated 타입을 재귀적으로 언랩핑
   - typing/typing_extensions 호환성 지원

2. **`_extract_from_obj()` 재귀 함수 개선**
   - Pydantic 모델 처리 유지 (하위 호환성)
   - dict 래핑 처리: `{'root': ...}` 형태 재귀 탐색
   - Typing generics 처리: `Dict[str, TypedDict]` 등 내부 타입 추출
   - `get_type_hints(include_extras=True)` 사용
   - `__annotations__` 폴백: TypedDict 필드명 직접 추출
   - 재귀 깊이 제한 (5단계): 무한 재귀 방지

3. **디버그 로깅 추가**
   - 실패 시 debug 레벨 로그로 문제 추적 용이

## Test Coverage

### 기본 스키마 테스트 (test_a2a_lg_agent_executor_schema.py)
- ✅ 단순 TypedDict
- ✅ Annotated 필드를 가진 TypedDict  
- ✅ Annotated로 래핑된 TypedDict
- ✅ root dict로 래핑된 TypedDict
- ✅ 일반 dict 스키마
- ✅ Pydantic v2 모델
- ✅ 중첩 TypedDict
- ✅ 빈 스키마 (None, empty TypedDict)
- ✅ 복잡한 Annotated 구조 (다중 래핑)

### LangGraph 통합 테스트 (test_a2a_lg_integration.py)
- ✅ BaseGraphState 상속
- ✅ Annotated 리듀서 패턴
- ✅ TypedDict State에서 payload → graph input 변환
- ✅ 기존 messages 필드의 LangChain 메시지 변환
- ✅ messages 필드명 감지
- ✅ Deep Research Agent State 패턴

### 테스트 결과
```
16 passed, 3 warnings in 0.41s
```

## Impact

### 직접 영향
- A2A로 래핑된 모든 LangGraph 에이전트
- TypedDict 기반 State를 사용하는 그래프
- Annotated 리듀서를 사용하는 그래프

### 개선 효과
1. ✅ TypedDict State 정상 작동
2. ✅ Annotated 리듀서 지원: `Annotated[list, add_messages]` 패턴
3. ✅ 중첩 구조 처리: `{'root': Annotated[TypedDict, ...]}` 구조
4. ✅ Pydantic 호환성 유지
5. ✅ 런타임 에러 감소

## Example

### Before (문제 발생)
```python
class MyState(TypedDict):
    messages: Annotated[list, add_messages]
    notes: list[str]

# _get_graph_input_field_names() 결과: set() 또는 {'root'}
# → 그래프 입력 구성 실패
```

### After (정상 작동)
```python
class MyState(TypedDict):
    messages: Annotated[list, add_messages]
    notes: list[str]

# _get_graph_input_field_names() 결과: {'messages', 'notes'}
# → 그래프 입력 정상 구성
```

## Compatibility

- ✅ Python 3.9+ (typing_extensions 폴백)
- ✅ LangGraph 0.6.2+
- ✅ Pydantic v1/v2
- ✅ 하위 호환성 유지